### PR TITLE
Fix configureHttp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-requests",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Request helpers",
   "main": "lib/index.js",
   "scripts": {

--- a/src/configure-http.js
+++ b/src/configure-http.js
@@ -24,7 +24,7 @@ import http from './http'
 
 function configureHttp (defaults) {
   return function configuredHttp (endpoint, options) {
-    return http(endpoint, { ...defaults, options })
+    return http(endpoint, { ...defaults, ...options })
   }
 }
 

--- a/test/configure-api.test.js
+++ b/test/configure-api.test.js
@@ -5,8 +5,9 @@ import { successUrl } from 'isomorphic-fetch'
 // returning options as the response
 
 test('configureApi adds defaults to request options', () => {
-  const myApi = configureApi({ foo: 'bar' })
-  return myApi.get(successUrl).then((res) => {
-    expect(res.foo).toEqual('bar')
+  const myApi = configureApi({ defaultVal: 'foo' })
+  return myApi.get(successUrl, { customVal: 'bar' }).then((res) => {
+    expect(res.defaultVal).toEqual('foo')
+    expect(res.customVal).toEqual('bar')
   })
 })

--- a/test/configure-http.test.js
+++ b/test/configure-http.test.js
@@ -5,8 +5,9 @@ import { successUrl } from 'isomorphic-fetch'
 // returning options as the response
 
 test('configureHttp adds defaults to request options', () => {
-  const myHttp = configureHttp({ foo: 'bar' })
-  return myHttp(successUrl).then((res) => {
-    expect(res.foo).toEqual('bar')
+  const myHttp = configureHttp({ defaultVal: 'foo' })
+  return myHttp(successUrl, { customVal: 'bar' }).then((res) => {
+    expect(res.defaultVal).toEqual('foo')
+    expect(res.customVal).toEqual('bar')
   })
 })


### PR DESCRIPTION
Request-specific options were being improperly nested under an `options` key.