### PR TITLE
Allow configuration methods to accept base instances

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -52,6 +52,7 @@ Note: This configuration can always be overridden by passing in options manually
 **Parameters**
 
 -   `config` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** An api configuration object
+-   `baseApi` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** An existing api instance to extend with the configuration
 
 **Examples**
 
@@ -73,6 +74,7 @@ Note: This configuration can always be overridden by passing in options manually
 **Parameters**
 
 -   `config` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** An http configuration object
+-   `baseHttp` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** An existing http instance to extend with the configuration
 
 **Examples**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-requests",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Request helpers",
   "main": "lib/index.js",
   "scripts": {

--- a/src/api.js
+++ b/src/api.js
@@ -33,33 +33,30 @@ import http from './http'
  *    .catch(err => console.log('An error occurred!', err))
  */
 
-export function api (defaults={}) {
-
-  function requestWithMethod (url, body, opts, method) {
-    return http(url, { ...defaults, ...opts, body, method })
+export class Api {
+  constructor (defaults={}) {
+    this.defaults = defaults
   }
-
-  return {
-    get (url, opts={}) {
-      const body = null
-      return requestWithMethod(url, body, opts, 'GET')
-    },
-    patch (url, body, opts={}) {
-      return requestWithMethod(url, body, opts, 'PATCH')
-    },
-    post (url, body, opts={}) {
-      return requestWithMethod(url, body, opts, 'POST')
-    },
-    put (url, body, opts={}) {
-      return requestWithMethod(url, body, opts, 'PUT')
-    },
-    destroy (url, body, opts={}) {
-      return requestWithMethod(url, body, opts, 'DELETE')
-    },
-    call (url, method, body, opts={}) {
-      return requestWithMethod(url, body, opts, method)
-    },
+  call (url, method, body, opts={}) {
+    return http(url, { ...this.defaults, ...opts, body, method })
+  }
+  get (url, opts={}) {
+    const body = null
+    return this.call(url, 'GET', body, opts)
+  }
+  patch (url, body, opts={}) {
+    return this.call(url, 'PATCH', body, opts)
+  }
+  post (url, body, opts={}) {
+    return this.call(url, 'POST', body, opts)
+  }
+  put (url, body, opts={}) {
+    return this.call(url, 'PUT', body, opts)
+  }
+  destroy (url, body, opts={}) {
+    return this.call(url, 'DELETE', body, opts)
   }
 }
 
-export default api()
+// Exports a single instance of the Api class
+export default new Api()

--- a/src/configure-api.js
+++ b/src/configure-api.js
@@ -1,4 +1,4 @@
-import { api } from './api'
+import { Api } from './api'
 
 /**
  * 
@@ -10,6 +10,7 @@ import { api } from './api'
  * @name configureApi
  * @type Function
  * @param {Object} config - An api configuration object
+ * @param {Object} [baseApi] - An existing api instance to extend with the configuration
  * @returns {Object} A configured api instance
  * 
  * @example
@@ -21,8 +22,8 @@ import { api } from './api'
  * 
  */
 
-function configureApi (defaults) {
-  return api(defaults)
+function configureApi (defaults, baseApi=new Api()) {
+  return new Api({ ...baseApi.defaults, ...defaults })
 }
 
 export default configureApi

--- a/src/configure-http.js
+++ b/src/configure-http.js
@@ -10,6 +10,7 @@ import http from './http'
  * @name configureHttp
  * @type Function
  * @param {Object} config - An http configuration object
+ * @param {Object} [baseHttp] - An existing http instance to extend with the configuration
  * @returns {Object} A configured http instance
  * 
  * @example
@@ -21,10 +22,9 @@ import http from './http'
  * 
  */
 
-
-function configureHttp (defaults) {
+function configureHttp (defaults, baseHttp=http) {
   return function configuredHttp (endpoint, options) {
-    return http(endpoint, { ...defaults, ...options })
+    return baseHttp(endpoint, { ...defaults, ...options })
   }
 }
 

--- a/test/configure-api.test.js
+++ b/test/configure-api.test.js
@@ -11,3 +11,13 @@ test('configureApi adds defaults to request options', () => {
     expect(res.customVal).toEqual('bar')
   })
 })
+
+test('configureApi can accept a custom base api', () => {
+  const myFirstApi = configureApi({ firstVal: 'foo' })
+  const mySecondApi = configureApi({ secondVal: 'bar' }, myFirstApi)
+  return mySecondApi.get(successUrl, { thirdVal: 'baz' }).then((res) => {
+    expect(res.firstVal).toEqual('foo')
+    expect(res.secondVal).toEqual('bar')
+    expect(res.thirdVal).toEqual('baz')
+  })
+})

--- a/test/configure-http.test.js
+++ b/test/configure-http.test.js
@@ -11,3 +11,13 @@ test('configureHttp adds defaults to request options', () => {
     expect(res.customVal).toEqual('bar')
   })
 })
+
+test('configureHttp can accept a custom base http', () => {
+  const myFirstHttp = configureHttp({ firstVal: 'foo' })
+  const mySecondHttp = configureHttp({ secondVal: 'bar' }, myFirstHttp)
+  return mySecondHttp(successUrl, { thirdVal: 'baz' }).then((res) => {
+    expect(res.firstVal).toEqual('foo')
+    expect(res.secondVal).toEqual('bar')
+    expect(res.thirdVal).toEqual('baz')
+  })
+})


### PR DESCRIPTION
So you can "extend" an existing configured instance.

Also rewrites API module as a class instead of a plain object (doesn't change usage)