### PR TITLE
Add `errors` as a separate property on HttpError

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -115,7 +115,7 @@ In addition to the normal Fetch API settings, the config object may also contain
 -   `'onSuccess'`: A function that will be called if the request succeeds. It will be passed the successful response. If it returns a value, `http` will resolve with this value instead of the response.
 -   `'onFailure'`: A function that will be called if the request fails. It will be passed the error that was thrown during the request. If it returns a value, `http` will reject with this value instead of the default error.
 -   `successDataPath`: A path to response data that the promise will resolve with.
--   `failureDataPath`: A path to response data that will be included in the HttpError object.
+-   `failureDataPath`: A path to the errors that will be included in the HttpError object (default=`'errors'`)
 -   `query`: An object that will be transformed into a query string and appended to the request URL.
 
 **Parameters**
@@ -158,6 +158,7 @@ In addition to the standard [Error](https://developer.mozilla.org/en-US/docs/Web
 -   `status` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** the status code of the response
 -   `statusText` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** the status text of the response
 -   `response` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** the full response object
+-   `errors` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** an array of error messages associated with the response (optional, default `[]`)
 
 **Examples**
 

--- a/docs.md
+++ b/docs.md
@@ -158,7 +158,7 @@ In addition to the standard [Error](https://developer.mozilla.org/en-US/docs/Web
 -   `status` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** the status code of the response
 -   `statusText` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** the status text of the response
 -   `response` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** the full response object
--   `errors` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** an array of error messages associated with the response (optional, default `[]`)
+-   `errors` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** an object containing error messages associated with the response (optional, default `{}`)
 
 **Examples**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-requests",
-  "version": "2.5.1",
+  "version": "3.0.0",
   "description": "Request helpers",
   "main": "lib/index.js",
   "scripts": {

--- a/src/http-error.js
+++ b/src/http-error.js
@@ -11,7 +11,7 @@
  * @param {Number} status - the status code of the response
  * @param {String} statusText - the status text of the response
  * @param {Object} response - the full response object
- * @param {Object} [errors=[]] - an array of error messages associated with the response
+ * @param {Object} [errors={}] - an object containing error messages associated with the response
  * 
  * @example
  *
@@ -24,7 +24,7 @@
  */
 
 export default class HttpError extends Error {
-  constructor (status, statusText, response, errors=[]) {
+  constructor (status, statusText, response, errors={}) {
     super()
     this.name = 'HttpError'
     this.status = status

--- a/src/http-error.js
+++ b/src/http-error.js
@@ -11,6 +11,7 @@
  * @param {Number} status - the status code of the response
  * @param {String} statusText - the status text of the response
  * @param {Object} response - the full response object
+ * @param {Object} [errors=[]] - an array of error messages associated with the response
  * 
  * @example
  *
@@ -23,12 +24,13 @@
  */
 
 export default class HttpError extends Error {
-  constructor (status, statusText, response) {
+  constructor (status, statusText, response, errors=[]) {
     super()
     this.name = 'HttpError'
     this.status = status
     this.statusText = statusText
     this.response = response
+    this.errors = errors
     this.message = `${status} - ${statusText}`
   }
 }

--- a/src/http/http.js
+++ b/src/http/http.js
@@ -102,7 +102,8 @@ function makeRequest (endpoint, options) {
       .then(json => {
         const camelized = camelizeKeys(json)
         if (response.ok) return getDataAtPath(camelized, successDataPath)
-        throw new HttpError(response.status, response.statusText, camelized, getDataAtPath(camelized, failureDataPath))
+        const errors = getDataAtPath(camelized, failureDataPath)
+        throw new HttpError(response.status, response.statusText, camelized, errors)
       })
     )
 }

--- a/src/http/http.js
+++ b/src/http/http.js
@@ -37,7 +37,7 @@ import {
  * - `'onSuccess'`: A function that will be called if the request succeeds. It will be passed the successful response. If it returns a value, `http` will resolve with this value instead of the response.
  * - `'onFailure'`: A function that will be called if the request fails. It will be passed the error that was thrown during the request. If it returns a value, `http` will reject with this value instead of the default error.
  * - `successDataPath`: A path to response data that the promise will resolve with.
- * - `failureDataPath`: A path to response data that will be included in the HttpError object.
+ * - `failureDataPath`: A path to the errors that will be included in the HttpError object (default=`'errors'`)
  * - `query`: An object that will be transformed into a query string and appended to the request URL.
  *
  * @name http
@@ -77,7 +77,7 @@ function makeRequest (endpoint, options) {
     headers={}, 
     bearerToken,
     successDataPath,
-    failureDataPath,
+    failureDataPath='errors',
     query,
     ...rest
   } = options
@@ -102,7 +102,7 @@ function makeRequest (endpoint, options) {
       .then(json => {
         const camelized = camelizeKeys(json)
         if (response.ok) return getDataAtPath(camelized, successDataPath)
-        throw new HttpError(response.status, response.statusText, getDataAtPath(camelized, failureDataPath))
+        throw new HttpError(response.status, response.statusText, camelized, getDataAtPath(camelized, failureDataPath))
       })
     )
 }

--- a/test/http-error.test.js
+++ b/test/http-error.test.js
@@ -4,11 +4,13 @@ test('HttpError has correct name, status, statusText and response', () => {
   const status = 500
   const statusText = 'Foo'
   const response = { bad: true }
-  const err = new HttpError(status, statusText, response)
+  const errors = [ 'my-error' ]
+  const err = new HttpError(status, statusText, response, errors)
   expect(err.name).toEqual('HttpError')
   expect(err.status).toEqual(status)
   expect(err.statusText).toEqual(statusText)
   expect(err.response).toEqual(response)
+  expect(err.errors).toEqual(errors)
 })
 
 test('HttpError builds message string correctly', () => {

--- a/test/http-error.test.js
+++ b/test/http-error.test.js
@@ -4,7 +4,7 @@ test('HttpError has correct name, status, statusText and response', () => {
   const status = 500
   const statusText = 'Foo'
   const response = { bad: true }
-  const errors = [ 'my-error' ]
+  const errors = { 'some-value': 'there was an error' }
   const err = new HttpError(status, statusText, response, errors)
   expect(err.name).toEqual('HttpError')
   expect(err.status).toEqual(status)

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -150,11 +150,12 @@ test('http pulls data from response using successDataPath', () => {
 
 test('http failureDataPath defaults to "errors"', () => {
   expect.assertions(1)
+  const ERRORS = { 'someValue': 'there was an error' }
   return http(failureUrl, {
     method: 'POST',
-    errors: [ 'my-error' ],
+    errors: ERRORS,
   }).catch((err) => {
-    expect(err.errors).toEqual([ 'my-error' ])
+    expect(err.errors).toEqual(ERRORS)
   })
 })
 

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -148,13 +148,24 @@ test('http pulls data from response using successDataPath', () => {
   })
 })
 
+test('http failureDataPath defaults to "errors"', () => {
+  expect.assertions(1)
+  return http(failureUrl, {
+    method: 'POST',
+    errors: [ 'my-error' ],
+  }).catch((err) => {
+    expect(err.errors).toEqual([ 'my-error' ])
+  })
+})
+
+
 test('http pulls data from failure response using failureDataPath', () => {
   expect.assertions(1)
   return http(failureUrl, {
     method: 'POST',
     failureDataPath: 'method',
   }).catch((err) => {
-    expect(err.response).toEqual('POST')
+    expect(err.errors).toEqual('POST')
   })
 })
 


### PR DESCRIPTION
This is a breaking change, as `failureDataPath` will no longer be used to determine `HttpError.response`.