### PR TITLE
Override headers

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -117,6 +117,7 @@ In addition to the normal Fetch API settings, the config object may also contain
 -   `successDataPath`: A path to response data that the promise will resolve with.
 -   `failureDataPath`: A path to the errors that will be included in the HttpError object (default=`'errors'`)
 -   `query`: An object that will be transformed into a query string and appended to the request URL.
+-   `overrideHeaders`: A boolean flag indicating whether or not default headers should be include in the request.
 
 **Parameters**
 

--- a/docs.md
+++ b/docs.md
@@ -117,7 +117,7 @@ In addition to the normal Fetch API settings, the config object may also contain
 -   `successDataPath`: A path to response data that the promise will resolve with.
 -   `failureDataPath`: A path to the errors that will be included in the HttpError object (default=`'errors'`)
 -   `query`: An object that will be transformed into a query string and appended to the request URL.
--   `overrideHeaders`: A boolean flag indicating whether or not default headers should be include in the request.
+-   `overrideHeaders`: A boolean flag indicating whether or not default headers should be include in the request (default=`false`).
 
 **Parameters**
 

--- a/docs.md
+++ b/docs.md
@@ -117,7 +117,7 @@ In addition to the normal Fetch API settings, the config object may also contain
 -   `successDataPath`: A path to response data that the promise will resolve with.
 -   `failureDataPath`: A path to the errors that will be included in the HttpError object (default=`'errors'`)
 -   `query`: An object that will be transformed into a query string and appended to the request URL.
--   `overrideHeaders`: A boolean flag indicating whether or not default headers should be include in the request (default=`false`).
+-   `overrideHeaders`: A boolean flag indicating whether or not default headers should be included in the request (default=`false`).
 
 **Parameters**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-requests",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Request helpers",
   "main": "lib/index.js",
   "scripts": {

--- a/src/http/http.js
+++ b/src/http/http.js
@@ -74,6 +74,7 @@ function makeRequest (endpoint, options) {
   const { 
     root, 
     csrf=true, 
+    overrideHeaders=false,
     headers={}, 
     bearerToken,
     successDataPath,
@@ -82,9 +83,11 @@ function makeRequest (endpoint, options) {
     ...rest
   } = options
   // Build fetch config
+  const allHeaders = { ...DEFAULT_OPTIONS.headers, ...getAuthHeaders(bearerToken), ...headers }
+  const requestHeaders = overrideHeaders ? { ...headers } : allHeaders
   const fetchConfig = omitUndefined({
     ...DEFAULT_OPTIONS,
-    headers: { ...DEFAULT_OPTIONS.headers, ...getAuthHeaders(bearerToken), ...headers },
+    headers: requestHeaders,
     ...rest,
   })
   // Decamlize and stringify body if it's a JSON request

--- a/src/http/http.js
+++ b/src/http/http.js
@@ -39,7 +39,7 @@ import {
  * - `successDataPath`: A path to response data that the promise will resolve with.
  * - `failureDataPath`: A path to the errors that will be included in the HttpError object (default=`'errors'`)
  * - `query`: An object that will be transformed into a query string and appended to the request URL.
- * - `overrideHeaders`: A boolean flag indicating whether or not default headers should be include in the request (default=`false`).
+ * - `overrideHeaders`: A boolean flag indicating whether or not default headers should be included in the request (default=`false`).
  *
  * @name http
  * @type Function
@@ -85,7 +85,7 @@ function makeRequest (endpoint, options) {
   } = options
   // Build fetch config
   const allHeaders = { ...DEFAULT_OPTIONS.headers, ...getAuthHeaders(bearerToken), ...headers }
-  const requestHeaders = overrideHeaders ? { ...headers } : allHeaders
+  const requestHeaders = overrideHeaders ? headers : allHeaders
   const fetchConfig = omitUndefined({
     ...DEFAULT_OPTIONS,
     headers: requestHeaders,

--- a/src/http/http.js
+++ b/src/http/http.js
@@ -39,6 +39,7 @@ import {
  * - `successDataPath`: A path to response data that the promise will resolve with.
  * - `failureDataPath`: A path to the errors that will be included in the HttpError object (default=`'errors'`)
  * - `query`: An object that will be transformed into a query string and appended to the request URL.
+ * - `overrideHeaders`: A boolean flag indicating whether or not default headers should be include in the request.
  *
  * @name http
  * @type Function

--- a/src/http/http.js
+++ b/src/http/http.js
@@ -39,7 +39,7 @@ import {
  * - `successDataPath`: A path to response data that the promise will resolve with.
  * - `failureDataPath`: A path to the errors that will be included in the HttpError object (default=`'errors'`)
  * - `query`: An object that will be transformed into a query string and appended to the request URL.
- * - `overrideHeaders`: A boolean flag indicating whether or not default headers should be include in the request.
+ * - `overrideHeaders`: A boolean flag indicating whether or not default headers should be include in the request (default=`false`).
  *
  * @name http
  * @type Function

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -89,6 +89,14 @@ test('http `before` is passed request options', () => {
   })
 })
 
+test('http overrides header object if `overrideHeaders` is passed to `before` hook', () => {
+  const before = () => ({ overrideHeaders: true, headers: { foo: 'bar' } })
+  return http(successUrl, { before }).then((res) => {
+    delete res.url
+    expect(res.headers).toEqual({ foo: 'bar' })
+  })
+})
+
 test('http onSuccess hook is called with request result', () => {
   expect.assertions(1)
   const onSuccess = jest.fn()


### PR DESCRIPTION
Adds ability to include a boolean flag `overrideHeaders` to the configured API instance that will completely override the default header object.