### PR TITLE
Use `base-64` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "rimraf": "^2.5.4"
   },
   "dependencies": {
-    "Base64": "^1.0.1",
     "babel-preset-react": "^6.24.1",
+    "base-64": "^0.1.0",
     "humps": "^2.0.0",
     "is-promise": "^2.1.0",
     "isomorphic-fetch": "^2.2.1",

--- a/src/http/middleware/set-auth-headers.js
+++ b/src/http/middleware/set-auth-headers.js
@@ -1,4 +1,4 @@
-import Base64 from 'Base64'
+import Base64 from 'base-64'
 
 // Sets auth headers if necessary
 
@@ -15,7 +15,7 @@ function addAuthHeaders ({
   if (auth) {
     const username = auth.username || ''
     const password = auth.password || ''
-    const encodedToken = Base64.btoa(`${ username }:${ password }`)
+    const encodedToken = Base64.encode(`${ username }:${ password }`)
     return {
       headers: { ...headers, Authorization: `Basic ${ encodedToken }` }
     }

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -1,4 +1,4 @@
-import Base64 from 'Base64'
+import Base64 from 'base-64'
 import { successUrl, failureUrl } from 'isomorphic-fetch'
 import { http } from '../src'
 
@@ -257,7 +257,7 @@ test('http sets basic auth header if `auth` is present', () => {
       password,
     }
   }).then(res => {
-    expect(res.headers.authorization).toEqual(`Basic ${ Base64.btoa(`${ username }:${ password }`) }`)
+    expect(res.headers.authorization).toEqual(`Basic ${ Base64.encode(`${ username }:${ password }`) }`)
   })
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,10 +78,6 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
-Base64@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/Base64/-/Base64-1.0.1.tgz#def45cc50c961bcc9bf2321d0f52bcbfec1f1bb1"
-
 JSONStream@^1.0.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -1408,6 +1404,10 @@ balanced-match@^0.4.1:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+base-64@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
 
 base64-js@^1.0.2:
   version "1.2.1"


### PR DESCRIPTION
Resolves #50 

Switched to a different package -- looks like `Base64` was installing as `base64` (lowercase) in `node_modules`, which was causing that import error. I think the `encode` method is clearer too