### PR TITLE
Handle responses with no content

### DIFF
--- a/__mocks__/isomorphic-fetch.js
+++ b/__mocks__/isomorphic-fetch.js
@@ -12,6 +12,9 @@ const statuses = {
 export default jest.fn(function (url, options) {
   const response = {
     // Response echoes back passed options
+    headers: {
+      get: () => {}
+    },
     json: () => Promise.resolve({ ...options, url }),
     ok: ![failureUrl, unauthorizedUrl].includes(url),
     status: statuses[url]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-requests",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "Request helpers",
   "main": "lib/index.js",
   "scripts": {

--- a/src/http/http.js
+++ b/src/http/http.js
@@ -84,7 +84,7 @@ export function parseArguments (...args) {
   return { ...options, url: firstArg }
 }
 
-// Default to pulling out JSON
+// Get JSON from response
 async function getResponseBody (response) {
   // Don't parse empty body
   if (response.headers.get('Content-Length') === '0') return null


### PR DESCRIPTION
Return `null` when `Content-Length` is zero.