### PR TITLE
Don't call onFailure when there's an error in onSuccess

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-requests",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "Request helpers",
   "main": "lib/index.js",
   "scripts": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,6 +14,7 @@ export { default as compose } from 'lodash/fp/compose'
 export { default as noop } from 'lodash/noop'
 export { default as union } from 'lodash/union'
 export { default as isString } from 'lodash/isString'
+export { default as isError } from 'lodash/isError'
 
 // A wrapper around the humps library
 // Converts all keys of the given object to camelCase
@@ -77,4 +78,14 @@ export async function asyncReduce (array, handler, initialValue) {
     result = await handler(result, value)
   }
   return result
+}
+
+// Async version of lodash attempt()
+// https://lodash.com/docs/4.17.15#attempt
+export async function attemptAsync (func, ...args)  {
+  try {
+    return await func(...args)
+  } catch(e) {
+    return e
+  }
 }

--- a/test/http/http.test.js
+++ b/test/http/http.test.js
@@ -133,6 +133,15 @@ test('http onFailure hook is called with request result', () => {
   })
 })
 
+test('http onFailure hook is not triggered when an error is thrown in onSuccess', () => {
+  expect.assertions(1)
+  const onSuccess = () => { throw new Error('Oops') }
+  const onFailure = jest.fn()
+  return http(successUrl, { onFailure, onSuccess }).catch(e => {
+    expect(onFailure).not.toHaveBeenCalled()
+  })
+})
+
 test('http onSuccess hook return value used as reject value', () => {
   const NEW_REJECT_VALUE = 'NEW_REJECT_VALUE'
   const onFailure = jest.fn(() => NEW_REJECT_VALUE)


### PR DESCRIPTION
Fixes a subtle bug in the original `try/catch` setup. Required to show better error messages when `onSuccess` fails.