### PR TITLE
Handle no content

### DIFF
--- a/__mocks__/isomorphic-fetch.js
+++ b/__mocks__/isomorphic-fetch.js
@@ -1,21 +1,29 @@
 export const successUrl = '/success'
+export const noContentUrl = '/no-content'
 export const failureUrl = '/failure'
 export const unauthorizedUrl = '/unauthorized'
 export const networkErrorUrl = '/network-error'
 
 const statuses = {
   [successUrl]: 200,
+  [noContentUrl]: 204,
   [failureUrl]: 400,
   [unauthorizedUrl]: 401
 }
 
 export default jest.fn(function (url, options) {
+  const { headers={} } = options
+  const body = { ...options, url }
+
   const response = {
     // Response echoes back passed options
     headers: {
-      get: () => {}
+      get: (header) => {
+        return headers[header]
+      },
+      ...headers,
     },
-    json: () => Promise.resolve({ ...options, url }),
+    json: () => Promise.resolve(body),
     ok: ![failureUrl, unauthorizedUrl].includes(url),
     status: statuses[url]
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-requests",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "Request helpers",
   "main": "lib/index.js",
   "scripts": {

--- a/src/http/http.js
+++ b/src/http/http.js
@@ -67,12 +67,12 @@ import {
  * getUsers()
  *    .then(res => console.log('The users are', res))
  *    .catch(err => console.log('An error occurred!', err))
- * 
+ *
  * // Shorthand: pass `url` as first argument:
  * function getUsers () {
  *   return http('/users', options)
  * }
- * 
+ *
  */
 
 // Enable shorthand with optional string `url` first argument.
@@ -85,9 +85,9 @@ export function parseArguments (...args) {
 }
 
 // Get JSON from response
-async function getResponseBody (response) {
+async function getResponseBody(response) {
   // Don't parse empty body
-  if (response.headers.get('Content-Length') === '0') return null
+  if (response.headers.get('Content-Length') === '0' || response.status === 204) return null
   try {
     return await response.json()
   } catch (e) {
@@ -98,13 +98,12 @@ async function getResponseBody (response) {
 }
 
 async function http (...args) {
-
-  const { 
+  const {
     before=noop,
     __mock_response, // used for unit testing
     ...options
   } = parseArguments(...args)
-  
+
   const parsedOptions = await composeMiddleware(
     before,
     setDefaults,
@@ -117,7 +116,7 @@ async function http (...args) {
   )(options)
 
   const {
-    onSuccess, 
+    onSuccess,
     onFailure,
     camelizeResponse,
     successDataPath,

--- a/test/http/http.test.js
+++ b/test/http/http.test.js
@@ -1,5 +1,5 @@
 import Base64 from 'Base64'
-import { successUrl, failureUrl } from 'isomorphic-fetch'
+import { successUrl, noContentUrl, failureUrl } from 'isomorphic-fetch'
 import { http } from '../../src'
 
 // These tests rely on the mock Fetch()
@@ -137,7 +137,7 @@ test('http onFailure hook is not triggered when an error is thrown in onSuccess'
   expect.assertions(1)
   const onSuccess = () => { throw new Error('Oops') }
   const onFailure = jest.fn()
-  return http(successUrl, { onFailure, onSuccess }).catch(e => {
+  return http(successUrl, { onFailure, onSuccess }).catch(() => {
     expect(onFailure).not.toHaveBeenCalled()
   })
 })
@@ -287,6 +287,20 @@ test('http sets basic auth header if `auth` is present', () => {
   }).then(res => {
     expect(res.headers.authorization).toEqual(`Basic ${ Base64.btoa(`${ username }:${ password }`) }`)
   })
+})
+
+test('http returns null when content-length is zero', () => {
+  return http(successUrl, { headers: { 'Content-Length': '0' }})
+    .then((res) => {
+      expect(res).toBe(null)
+    })
+})
+
+test('http returns null when the status is 204 (no content)', () => {
+  return http(noContentUrl)
+    .then((res) => {
+      expect(res).toBe(null)
+    })
 })
 
 /* MOCK STUFF */


### PR DESCRIPTION
Resolves #90 

This is not a breaking change because the current behavior is to return null and log a warning message. This change simply short circuits the function before `.json()` is invoked and only returns null.

This isn't handled natively by the Response object and follows the approach recommended here: https://github.com/whatwg/fetch/issues/113#issuecomment-409922366. 
