### PR TITLE
Fall back to text body

### DIFF
--- a/__mocks__/isomorphic-fetch.js
+++ b/__mocks__/isomorphic-fetch.js
@@ -1,21 +1,29 @@
 export const successUrl = '/success'
+export const noContentUrl = '/no-content'
 export const failureUrl = '/failure'
 export const unauthorizedUrl = '/unauthorized'
 export const networkErrorUrl = '/network-error'
 
 const statuses = {
   [successUrl]: 200,
+  [noContentUrl]: 204,
   [failureUrl]: 400,
   [unauthorizedUrl]: 401
 }
 
 export default jest.fn(function (url, options) {
+  const { headers={} } = options
+  const body = { ...options, url }
+
   const response = {
     // Response echoes back passed options
     headers: {
-      get: () => {}
+      get: (header) => {
+        return headers[header]
+      },
+      ...headers,
     },
-    json: () => Promise.resolve({ ...options, url }),
+    json: () => Promise.resolve(body),
     ok: ![failureUrl, unauthorizedUrl].includes(url),
     status: statuses[url]
   }

--- a/docs.md
+++ b/docs.md
@@ -171,6 +171,7 @@ In addition to the normal Fetch API settings, the config object may also contain
 -   `camelizeResponse`: A boolean flag indicating whether or not to camelize the response keys (default=`true`). The helper function that does this is also exported from this library as `camelizeKeys`.
 -   `decamelizeBody`: A boolean flag indicating whether or not to decamelize the body keys (default=`true`). The helper function that does this is also exported from this library as `decamelizeKeys`.
 -   `decamelizeQuery`: A boolean flag indicating whether or not to decamelize the query string keys (default=`true`).
+-   `parseJsonStrictly`: A boolean flag indicating whether or not to return the text of the response body if JSON parsing fails (default=`true`). If set to `true` and invalid JSON is received in the response, then `null` will be returned instead.
 -   `auth`: An object with the following keys `{ username, password }`. If present, `http` will use [basic auth][28], adding the header `"Authorization": "Basic <authToken>"` to the request, where `<authToken>` is a base64 encoded string of `username:password`.
 
 ### Parameters

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-requests",
-  "version": "4.1.9",
+  "version": "4.2.0",
   "description": "Request helpers",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-requests",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "Request helpers",
   "main": "lib/index.js",
   "scripts": {

--- a/src/http/http.js
+++ b/src/http/http.js
@@ -67,12 +67,12 @@ import {
  * getUsers()
  *    .then(res => console.log('The users are', res))
  *    .catch(err => console.log('An error occurred!', err))
- * 
+ *
  * // Shorthand: pass `url` as first argument:
  * function getUsers () {
  *   return http('/users', options)
  * }
- * 
+ *
  */
 
 // Enable shorthand with optional string `url` first argument.
@@ -85,9 +85,9 @@ export function parseArguments (...args) {
 }
 
 // Get JSON from response
-async function getResponseBody (response) {
+async function getResponseBody(response) {
   // Don't parse empty body
-  if (response.headers.get('Content-Length') === '0') return null
+  if (response.headers.get('Content-Length') === '0' || response.status === 204) return null
   try {
     return await response.json()
   } catch (e) {
@@ -98,13 +98,12 @@ async function getResponseBody (response) {
 }
 
 async function http (...args) {
-
-  const { 
+  const {
     before=noop,
     __mock_response, // used for unit testing
     ...options
   } = parseArguments(...args)
-  
+
   const parsedOptions = await composeMiddleware(
     before,
     setDefaults,
@@ -117,7 +116,7 @@ async function http (...args) {
   )(options)
 
   const {
-    onSuccess, 
+    onSuccess,
     onFailure,
     camelizeResponse,
     successDataPath,

--- a/src/http/http.js
+++ b/src/http/http.js
@@ -47,6 +47,7 @@ import {
  * - `camelizeResponse`: A boolean flag indicating whether or not to camelize the response keys (default=`true`). The helper function that does this is also exported from this library as `camelizeKeys`.
  * - `decamelizeBody`: A boolean flag indicating whether or not to decamelize the body keys (default=`true`). The helper function that does this is also exported from this library as `decamelizeKeys`.
  * - `decamelizeQuery`: A boolean flag indicating whether or not to decamelize the query string keys (default=`true`).
+ * - `parseJsonStrictly`: A boolean flag indicating whether or not to return the text of the response body if JSON parsing fails (default=`true`). If set to `true` and invalid JSON is received in the response, then `null` will be returned instead.
  * - `auth`: An object with the following keys `{ username, password }`. If present, `http` will use [basic auth](https://en.wikipedia.org/wiki/Basic_access_authentication#Client_side), adding the header `"Authorization": "Basic <authToken>"` to the request, where `<authToken>` is a base64 encoded string of `username:password`.
  *
  * @name http

--- a/src/http/middleware/set-defaults.js
+++ b/src/http/middleware/set-defaults.js
@@ -3,10 +3,11 @@ import { identity } from '../../utils'
 const DEFAULTS = {
   credentials: 'same-origin',
   mode: 'same-origin',
-  onSuccess: identity, 
+  onSuccess: identity,
   onFailure: identity,
   camelizeResponse: true,
   failureDataPath: 'errors',
+  parseJsonStrictly: true,
 }
 
 const DEFAULT_HEADERS = {

--- a/test/http/http.test.js
+++ b/test/http/http.test.js
@@ -1,5 +1,5 @@
 import Base64 from 'Base64'
-import { successUrl, failureUrl } from 'isomorphic-fetch'
+import { successUrl, noContentUrl, failureUrl } from 'isomorphic-fetch'
 import { http } from '../../src'
 
 // These tests rely on the mock Fetch()
@@ -137,7 +137,7 @@ test('http onFailure hook is not triggered when an error is thrown in onSuccess'
   expect.assertions(1)
   const onSuccess = () => { throw new Error('Oops') }
   const onFailure = jest.fn()
-  return http(successUrl, { onFailure, onSuccess }).catch(e => {
+  return http(successUrl, { onFailure, onSuccess }).catch(() => {
     expect(onFailure).not.toHaveBeenCalled()
   })
 })
@@ -287,6 +287,20 @@ test('http sets basic auth header if `auth` is present', () => {
   }).then(res => {
     expect(res.headers.authorization).toEqual(`Basic ${ Base64.btoa(`${ username }:${ password }`) }`)
   })
+})
+
+test('http returns null when content-length is zero', () => {
+  return http(successUrl, { headers: { 'Content-Length': '0' }})
+    .then((res) => {
+      expect(res).toBe(null)
+    })
+})
+
+test('http returns null when the status is 204 (no content)', () => {
+  return http(noContentUrl)
+    .then((res) => {
+      expect(res).toBe(null)
+    })
 })
 
 /* MOCK STUFF */


### PR DESCRIPTION
**Note**: Changes dependent on #95 

Resolves #93 

This adds a new option which will determine whether or not to perform a "strict" JSON parse on the response's body. Strict in this sense essentially means `response.json().catch(() => null)`. This will be the default behavior, which matches how the behavior currently works in `v4.1.9`. If the option is set to `false`, then a failed parsing will default to returning the text of the body, which will be left to the client to handle appropriately.

The use case that we're intending to solve for here is when a 3rd Party API doesn't escape a string response. E.g.,
```js
getThirdPartyToken() // response: 123AZY
// vs.
getThirdPartyToken() // response: "123AZY"
```
The first response will fail `JSON.parse`, while the other will succeed.

This implementation was inspired by Axios' implementation:
![Image 2021-09-06 at 9 24 40 AM](https://user-images.githubusercontent.com/20426095/132231570-284f9a0a-a2d2-4424-a6ea-4526ccbc4201.jpg)
